### PR TITLE
feat: add campuscreatedto initialregistrationpattern attribute

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/Campus.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/Campus.java
@@ -20,6 +20,7 @@ public class Campus {
     private UUID id;
     private String name;
     private String abbreviation;
+    private String initialRegistrationPattern;
     @Embedded
     private Address address;
     @Embedded
@@ -27,10 +28,11 @@ public class Campus {
     @Enumerated(EnumType.STRING)
     private EntityStatus status;
 
-    public Campus(String name, String abbreviation, Address address, InternshipSector internshipSector) {
+    public Campus(String name, String abbreviation, String initialRegistrationPattern, Address address, InternshipSector internshipSector) {
         this.id = UUID.randomUUID();
         this.name = name;
         this.abbreviation = abbreviation;
+        this.initialRegistrationPattern = initialRegistrationPattern;
         this.address = address;
         this.internshipSector = internshipSector;
         this.status = EntityStatus.ENABLED;

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusAlreadyExistsbyInitialRegistrationPatternException.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusAlreadyExistsbyInitialRegistrationPatternException.java
@@ -1,0 +1,12 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.exceptions.ResourceAlreadyExistsException;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.exceptions.ResourceName;
+import lombok.Getter;
+
+@Getter
+public class CampusAlreadyExistsbyInitialRegistrationPatternException extends ResourceAlreadyExistsException {
+    public CampusAlreadyExistsbyInitialRegistrationPatternException (String initialRegistrationPatternException){
+        super(ResourceName.INITIAL_REGISTRATION_PATTERN, "Initial Registration Pattern", initialRegistrationPatternException );
+    }
+}

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusCreateDto.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusCreateDto.java
@@ -1,5 +1,6 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.annotations.Alpha;
 import lombok.Value;
 
 import javax.validation.Valid;
@@ -19,6 +20,7 @@ public class CampusCreateDto {
     @NotNull
     @NotBlank
     @Size(min = 2, max = 2)
+    @Alpha
     String initialRegistrationPattern;
     @NotNull
     @Valid

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusCreateDto.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusCreateDto.java
@@ -17,6 +17,10 @@ public class CampusCreateDto {
     @Size(min = 3, max = 3)
     String abbreviation;
     @NotNull
+    @NotBlank
+    @Size(min = 2, max = 2)
+    String initialRegistrationPattern;
+    @NotNull
     @Valid
     AddressCreateDto address;
     @NotNull

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDto.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDto.java
@@ -10,7 +10,7 @@ public class CampusDto {
     UUID id;
     String name;
     String abbreviation;
-    String initialRegistrationPatter;
+    String initialRegistrationPattern;
     AddressDto address;
     InternshipSectorDto internshipSector;
     EntityStatus status;

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDto.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDto.java
@@ -10,6 +10,7 @@ public class CampusDto {
     UUID id;
     String name;
     String abbreviation;
+    String initialRegistrationPatter;
     AddressDto address;
     InternshipSectorDto internshipSector;
     EntityStatus status;

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDtoSimplified.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDtoSimplified.java
@@ -9,4 +9,5 @@ public class CampusDtoSimplified {
     UUID id;
     String name;
     String abbreviation;
+    String initialRegistrationPatter;
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDtoSimplified.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusDtoSimplified.java
@@ -9,5 +9,5 @@ public class CampusDtoSimplified {
     UUID id;
     String name;
     String abbreviation;
-    String initialRegistrationPatter;
+    String initialRegistrationPattern;
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
@@ -12,10 +12,12 @@ import java.util.UUID;
 public interface CampusRepository extends JpaRepository<Campus, UUID> {
     boolean existsByAbbreviation(String abbreviation);
     boolean existsByInternshipSectorEmail(String email);
+    boolean existsByInitialRegistrationPattern(String initialRegistrationPattern);
     @Query("select count(c) > 0 from Campus c where c.internshipSector.email = ?1 and c.id <> ?2")
     boolean existsByEmailExcludedId(String email, UUID id);
     @Query("select count(c) > 0 from Campus c where c.abbreviation = ?1 and c.id <> ?2")
     boolean existsByAbbreviationExcludedId(String abbreviation, UUID id);
+    @Query ("select count(c) > 0 from Campus c where c.initialRegistrationPattern = ?1 and c.id <> ?2")
+    boolean existsByInitialRegistrationPattern(String initialRegistrationPattern, UUID id);
     List<Campus> findAllByStatus(EntityStatus status);
-
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
@@ -18,6 +18,6 @@ public interface CampusRepository extends JpaRepository<Campus, UUID> {
     @Query("select count(c) > 0 from Campus c where c.abbreviation = ?1 and c.id <> ?2")
     boolean existsByAbbreviationExcludedId(String abbreviation, UUID id);
     @Query ("select count(c) > 0 from Campus c where c.initialRegistrationPattern = ?1 and c.id <> ?2")
-    boolean existsByInitialRegistrationPattern(String initialRegistrationPattern, UUID id);
+    boolean existsByInitialRegistrationPatternExcludedId(String initialRegistrationPattern, UUID id);
     List<Campus> findAllByStatus(EntityStatus status);
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
@@ -43,7 +43,7 @@ public class CampusServiceImpl implements CampusService {
             throw new CampusAlreadyExistsByAbbreviationException(campusCreateDto.getAbbreviation());
         }
         if (campusRepository.existsByInitialRegistrationPattern(campusCreateDto.getInitialRegistrationPattern())){
-            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getAbbreviation());
+            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getInitialRegistrationPattern());
         }
         if (campusRepository.existsByInternshipSectorEmail(campusCreateDto.getInternshipSector().getEmail())) {
             throw new CampusAlreadyExistsByEmailException(campusCreateDto.getInternshipSector().getEmail());
@@ -78,7 +78,7 @@ public class CampusServiceImpl implements CampusService {
             throw new CampusAlreadyExistsByAbbreviationException(campusCreateDto.getAbbreviation());
         }
         if (campusRepository.existsByInitialRegistrationPattern(campusCreateDto.getInitialRegistrationPattern())){
-            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getAbbreviation());
+            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getInitialRegistrationPattern());
         }
         if (campusRepository.existsByEmailExcludedId(campusCreateDto.getInternshipSector().getEmail(), id)) {
             throw new CampusAlreadyExistsByEmailException(campusCreateDto.getInternshipSector().getEmail());

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
@@ -77,7 +77,7 @@ public class CampusServiceImpl implements CampusService {
         if (campusRepository.existsByAbbreviationExcludedId(campusCreateDto.getAbbreviation(), id)) {
             throw new CampusAlreadyExistsByAbbreviationException(campusCreateDto.getAbbreviation());
         }
-        if (campusRepository.existsByInitialRegistrationPattern(campusCreateDto.getInitialRegistrationPattern())){
+        if (campusRepository.existsByInitialRegistrationPatternExcludedId(campusCreateDto.getInitialRegistrationPattern(), id)){
             throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getInitialRegistrationPattern());
         }
         if (campusRepository.existsByEmailExcludedId(campusCreateDto.getInternshipSector().getEmail(), id)) {

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
@@ -42,6 +42,9 @@ public class CampusServiceImpl implements CampusService {
         if (campusRepository.existsByAbbreviation(campusCreateDto.getAbbreviation())) {
             throw new CampusAlreadyExistsByAbbreviationException(campusCreateDto.getAbbreviation());
         }
+        if (campusRepository.existsByInitialRegistrationPattern(campusCreateDto.getInitialRegistrationPattern())){
+            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getAbbreviation());
+        }
         if (campusRepository.existsByInternshipSectorEmail(campusCreateDto.getInternshipSector().getEmail())) {
             throw new CampusAlreadyExistsByEmailException(campusCreateDto.getInternshipSector().getEmail());
         }
@@ -73,6 +76,9 @@ public class CampusServiceImpl implements CampusService {
         getCampus(id);
         if (campusRepository.existsByAbbreviationExcludedId(campusCreateDto.getAbbreviation(), id)) {
             throw new CampusAlreadyExistsByAbbreviationException(campusCreateDto.getAbbreviation());
+        }
+        if (campusRepository.existsByInitialRegistrationPattern(campusCreateDto.getInitialRegistrationPattern())){
+            throw new CampusAlreadyExistsbyInitialRegistrationPatternException(campusCreateDto.getAbbreviation());
         }
         if (campusRepository.existsByEmailExcludedId(campusCreateDto.getInternshipSector().getEmail(), id)) {
             throw new CampusAlreadyExistsByEmailException(campusCreateDto.getInternshipSector().getEmail());

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
@@ -121,6 +121,7 @@ public class CampusServiceImpl implements CampusService {
         return new Campus(
             campusCreateDto.getName(),
             campusCreateDto.getAbbreviation(),
+            campusCreateDto.getInitialRegistrationPattern(),
             toAddress(campusCreateDto.getAddress(), city),
             toInternshipSector(campusCreateDto.getInternshipSector())
         );

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/exceptions/ResourceName.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/exceptions/ResourceName.java
@@ -16,6 +16,7 @@ public enum ResourceName {
     CURRICULUM("Curriculum"),
     ADVISOR_REQUEST("Advisor Request"),
     INTERNSHIP("Internship"),
+    INITIAL_REGISTRATION_PATTERN("Initial Registration Pattern"),
     ACTIVITY_PLAN("Activity Plan"),
     MONTHLY_REPORT("Monthly Report"),
     DRAFT_MONTHLY_REPORT_SUBMISSION("Draft Monthly Report Submission"),

--- a/src/main/resources/db/migration/V3__create_campuses_table.sql
+++ b/src/main/resources/db/migration/V3__create_campuses_table.sql
@@ -2,6 +2,7 @@ CREATE TABLE campuses(
     id UUID NOT NULL,
     name VARCHAR NOT NULL,
     abbreviation VARCHAR NOT NULL UNIQUE,
+    initial_registration_pattern VARCHAR NOT NULL UNIQUE,
     postal_code VARCHAR NOT NULL,
     street VARCHAR NOT NULL,
     neighborhood VARCHAR NOT NULL,

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusFactoryUtils.java
@@ -6,6 +6,7 @@ public class CampusFactoryUtils {
     public static Campus sampleCampus(City city) {
         String name = "Test Campus";
         String abbreviation = "TCS";
+        String initialRegistrationPattern = "SP";
         String postalCode = "123456";
         String street = "Test Street";
         String neighborhood = "Test Neighborhood";
@@ -17,6 +18,6 @@ public class CampusFactoryUtils {
         String website = "https://testcampus.com";
         InternshipSector internshipSector = new InternshipSector(telephone, email, website);
 
-        return new Campus(name, abbreviation, address, internshipSector);
+        return new Campus(name, abbreviation, initialRegistrationPattern, address, internshipSector);
     }
 }


### PR DESCRIPTION
resolves issue #106

Este pull request adiciona o atributo `initial registration pattern` e as suas validações nas classes necessárias, como `CampusCreateDTO` e `Campus` , para que esse campo seja atribuído à tabela de campuses.

As modificações podem ser testadas com o software Postman, que permite enviar solicitações para o servidor, como:
- **POST** /campuses colocando initial registration pattern  com valores válidos

- **POST** /campuses colocando initial registration pattern com valores inválidos (maior/menor que 2 caracteres, duplicado, números e vazio)

- **PUT** / campuses/ id com valores válidos e inválidos, tal como o POST.

- **GET** / campuses e GET/ campuses/ id

- **DELETE** / campuses / id

É possível melhorar a validação de outros campos como o abbreviation, pois ele permite ao usuário colocar caracteres diferentes de letras, como "___" ou "***".