### PR TITLE
feat: add campus filter by status

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
@@ -1,9 +1,12 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -14,4 +17,7 @@ public interface CampusRepository extends JpaRepository<Campus, UUID> {
     boolean existsByEmailExcludedId(String email, UUID id);
     @Query("select count(c) > 0 from Campus c where c.abbreviation = ?1 and c.id <> ?2")
     boolean existsByAbbreviationExcludedId(String abbreviation, UUID id);
+    @Query("select u from Campus u where u.status = :status")
+    List<Campus> findAllByStatus (@Param("status") EntityStatus status);
+
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepository.java
@@ -3,7 +3,6 @@ package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,7 +16,6 @@ public interface CampusRepository extends JpaRepository<Campus, UUID> {
     boolean existsByEmailExcludedId(String email, UUID id);
     @Query("select count(c) > 0 from Campus c where c.abbreviation = ?1 and c.id <> ?2")
     boolean existsByAbbreviationExcludedId(String abbreviation, UUID id);
-    @Query("select u from Campus u where u.status = :status")
-    List<Campus> findAllByStatus (@Param("status") EntityStatus status);
+    List<Campus> findAllByStatus(EntityStatus status);
 
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,12 +28,12 @@ public class CampusRestController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CampusDto>> index() {
+    public ResponseEntity<List<CampusDto>> index(@RequestParam EntityStatus status) {
         List<CampusDto> campuses = campusService.findAll().stream()
             .map(campusMapper::to)
             .collect(Collectors.toList());
         return ResponseEntity.ok(campuses);
-    }
+    } 
 
     @GetMapping("{id}")
     public ResponseEntity<CampusDto> show(@PathVariable UUID id) {

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -29,7 +29,16 @@ public class CampusRestController {
 
     @GetMapping
     public ResponseEntity<List<CampusDto>> index(@RequestParam EntityStatus status) {
-        List<CampusDto> campuses = campusService.findAll().stream()
+        List<CampusDto> campuses;
+
+        if(status == EntityStatus.ENABLED) {
+            campuses = campusService.findAll().stream()
+                    .filter(c -> c.getStatus() == EntityStatus.ENABLED)
+                    .map(campusMapper::to)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok(campuses);
+        }
+        campuses = campusService.findAll().stream()
             .map(campusMapper::to)
             .collect(Collectors.toList());
         return ResponseEntity.ok(campuses);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -38,6 +38,15 @@ public class CampusRestController {
                     .collect(Collectors.toList());
             return ResponseEntity.ok(campuses);
         }
+
+        if(status == EntityStatus.DISABLED) {
+            campuses = campusService.findAll().stream()
+                    .filter(c -> c.getStatus() == EntityStatus.DISABLED)
+                    .map(campusMapper::to)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok(campuses);
+        }
+
         campuses = campusService.findAll().stream()
             .map(campusMapper::to)
             .collect(Collectors.toList());

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -31,17 +31,8 @@ public class CampusRestController {
     public ResponseEntity<List<CampusDto>> index(@RequestParam (required = false) EntityStatus status) {
         List<CampusDto> campuses;
 
-        if(status == EntityStatus.ENABLED) {
-            campuses = campusService.findAll().stream()
-                    .filter(c -> c.getStatus() == EntityStatus.ENABLED)
-                    .map(campusMapper::to)
-                    .collect(Collectors.toList());
-            return ResponseEntity.ok(campuses);
-        }
-
-        if(status == EntityStatus.DISABLED) {
-            campuses = campusService.findAll().stream()
-                    .filter(c -> c.getStatus() == EntityStatus.DISABLED)
+        if(status != null) {
+            campuses = campusService.findAllByStatus(status).stream()
                     .map(campusMapper::to)
                     .collect(Collectors.toList());
             return ResponseEntity.ok(campuses);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -28,7 +28,7 @@ public class CampusRestController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CampusDto>> index(@RequestParam (required = false) EntityStatus status) {
+    public ResponseEntity<List<CampusDto>> index(@RequestParam(required = false) EntityStatus status) {
         List<CampusDto> campuses;
 
         if(status != null) {

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRestController.java
@@ -28,7 +28,7 @@ public class CampusRestController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CampusDto>> index(@RequestParam EntityStatus status) {
+    public ResponseEntity<List<CampusDto>> index(@RequestParam (required = false) EntityStatus status) {
         List<CampusDto> campuses;
 
         if(status == EntityStatus.ENABLED) {

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusService.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusService.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import java.util.UUID;
 public interface CampusService {
     Campus create(CampusCreateDto campusCreateDto);
     List<Campus> findAll();
+    List<Campus> findAllByStatus(EntityStatus status);
     Campus findById(UUID id);
     Campus update(UUID id, CampusCreateDto campusCreateDto);
     Campus setStatus(UUID id, EntityUpdateStatusDto campusUpdateStatusDto);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusServiceImpl.java
@@ -59,6 +59,11 @@ public class CampusServiceImpl implements CampusService {
     }
 
     @Override
+    public List<Campus> findAllByStatus(EntityStatus status) {
+        return campusRepository.findAllByStatus(status);
+    }
+
+    @Override
     public Campus findById(UUID id) {
         return getCampus(id);
     }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/WebConfig.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/WebConfig.java
@@ -1,0 +1,14 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.converters.StringToEntityStatusEnumConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToEntityStatusEnumConverter());
+    }
+}

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/converters/StringToEntityStatusEnumConverter.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/converters/StringToEntityStatusEnumConverter.java
@@ -1,0 +1,12 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.converters;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToEntityStatusEnumConverter implements Converter<String, EntityStatus> {
+
+    @Override
+    public EntityStatus convert(String source) {
+        return EntityStatus.valueOf(source.toUpperCase());
+    }
+}


### PR DESCRIPTION
Resolves issue #110 

Neste pull request, foi adicionado o parâmetro de requisição `status` na action `index` do controller `CampusRestController`. Tal parâmetro é um enum e, em função disso, precisa ter seus valores em letras maiúsculas. Então houve a necessidade de implementar um `converter`, pois pode ser passado no parâmetro de requisição o status do campus com letras maiúsculas e minúsculas. Para implementar essa solução, foi necessário criar a classe `StringToEntityStatusEnumConverter`, a qual transforma a string passada no parâmetro da requisição em letras maiúsculas e converte a mesma no enum `EntityStatus`. Ademais, também precisou criar a classe `WebConfig` para ser possível utilizar o `converter` criado. Também foi modificada a action `index` para que seja retornada uma lista de campus filtrados quando o parâmetro de requisição não for nulo, além de adicionar, no `CampusServiceImp`, `CampusService` e `CampusRepository`, o método que retorna uma lista de campus filtrados de acordo com o status passado.

Para verificar se essas modificações funcionam, basta utilizar o software Postman e realizar as seguintes requisições:
`http://localhost:8080/api/v1/campuses?status=DISABLED`  Deve retornar uma lista de campus desabilitados;
`http://localhost:8080/api/v1/campuses?status=disabled`  Deve retornar uma lista de campus desabilitados;
`http://localhost:8080/api/v1/campuses?status=ENABLED`  Deve retornar uma lista de campus habilitados;
`http://localhost:8080/api/v1/campuses?status=enabled`  Deve retornar uma lista de campus habilitados;
`http://localhost:8080/api/v1/campuses`  Deve retornar uma lista contendo todos os campus.

Uma possível melhoria seria adicionar um tratamento de exceções na classe `StringToEntityStatusEnumConverter`, visto que o método `valueOf` lançará uma exceção se for passado no parâmetro de requisição um valor não existente no enum `EntityStatus`.