### PR TITLE
refactor: cors allowed origin pattern for netlify previews

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/CorsConfig.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/common/CorsConfig.java
@@ -20,7 +20,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin(frontendUrl);
+        config.addAllowedOriginPattern("*" + frontendUrl);
         config.addAllowedHeader("*");
         config.setAllowedMethods(Arrays.asList("GET","POST", "PUT", "DELETE", "PATCH"));
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-