### PR TITLE
feat: add max annotation to number of periods

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseCreateDto.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseCreateDto.java
@@ -19,6 +19,7 @@ public class CourseCreateDto {
     String abbreviation;
     @NotNull
     @Positive
+    @Max(value = 20)
     Integer numberOfPeriods;
     @NotNull
     UUID departmentId;


### PR DESCRIPTION
Resolves #123

Foi adicionado a anotação max para o atributo `numberOfPeriods`, da classe `CourseCreateDto` - objeto usado no momento de criar e atualizar um curso. Nessa anotação é passado um limite máximo para o atributo, assim, não é permitido criar ou atualizar um curso com um Número de Períodos maior que 20.