### PR TITLE
feat: add parameter on index of course rest controller

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepository.java
@@ -1,8 +1,10 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
 
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +21,6 @@ public interface CourseRepository extends JpaRepository<Course, UUID> {
     boolean existsByDepartmentId(UUID departmentId);
     List<Course> findAllByDepartmentId(UUID departmentId);
     List<Course> findByIdIn(List<UUID> coursesIds);
+    @Query("select u from Course u where u.status = :status")
+    List<Course> findAllByStatus(@Param("status") EntityStatus status);
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepository.java
@@ -4,7 +4,6 @@ import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,6 +20,6 @@ public interface CourseRepository extends JpaRepository<Course, UUID> {
     boolean existsByDepartmentId(UUID departmentId);
     List<Course> findAllByDepartmentId(UUID departmentId);
     List<Course> findByIdIn(List<UUID> coursesIds);
-    @Query("select u from Course u where u.status = :status")
-    List<Course> findAllByStatus(@Param("status") EntityStatus status);
+    List<Course> findAllByStatus(EntityStatus status);
+
 }

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +29,7 @@ public class CourseRestController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CourseDto>> index() {
+    public ResponseEntity<List<CourseDto>> index(@RequestParam(required = false) EntityStatus status) {
         List<CourseDto> courses = courseService.findAll().stream()
             .map(courseMapper::to)
             .collect(Collectors.toList());

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
@@ -30,7 +30,16 @@ public class CourseRestController {
 
     @GetMapping
     public ResponseEntity<List<CourseDto>> index(@RequestParam(required = false) EntityStatus status) {
-        List<CourseDto> courses = courseService.findAll().stream()
+        List<CourseDto> courses;
+
+        if (status == EntityStatus.ENABLED) {
+            courses = courseService.findAll().stream()
+                    .filter(c -> c.getStatus() == EntityStatus.ENABLED)
+                    .map(courseMapper::to)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok(courses);
+        }
+        courses = courseService.findAll().stream()
             .map(courseMapper::to)
             .collect(Collectors.toList());
         return ResponseEntity.ok(courses);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRestController.java
@@ -32,16 +32,16 @@ public class CourseRestController {
     public ResponseEntity<List<CourseDto>> index(@RequestParam(required = false) EntityStatus status) {
         List<CourseDto> courses;
 
-        if (status == EntityStatus.ENABLED) {
-            courses = courseService.findAll().stream()
-                    .filter(c -> c.getStatus() == EntityStatus.ENABLED)
+        if (status != null) {
+            courses = courseService.findAllByStatus(status).stream()
                     .map(courseMapper::to)
                     .collect(Collectors.toList());
             return ResponseEntity.ok(courses);
         }
+
         courses = courseService.findAll().stream()
-            .map(courseMapper::to)
-            .collect(Collectors.toList());
+                .map(courseMapper::to)
+                .collect(Collectors.toList());
         return ResponseEntity.ok(courses);
     }
 

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseService.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseService.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import java.util.UUID;
 public interface CourseService {
     Course create(CourseCreateDto courseCreateDto);
     List<Course> findAll();
+    List<Course> findAllByStatus(EntityStatus status);
     Course findById(UUID courseId);
     Course update(UUID courseId, CourseCreateDto courseCreateDto);
     Course setStatus(UUID courseId, EntityUpdateStatusDto courseUpdateStatusDto);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseServiceImpl.java
@@ -67,6 +67,11 @@ public class CourseServiceImpl implements CourseService {
     }
 
     @Override
+    public List<Course> findAllByStatus(EntityStatus status) {
+        return courseRepository.findAllByStatus(status);
+    }
+
+    @Override
     public Course findById(UUID courseId) {
         return getCourse(courseId);
     }


### PR DESCRIPTION
Resolve a issue #131  

Neste pull request foi adicionado um parâmetro na action <code>index</code> da <code>CourseRestController</code>. Esse parâmetro é anotado com <code>required = false</code> e é um status do tipo <code>EntityStatus (enum)</code>. Caso este parâmetro não seja nulo, a index retorna um <code>ResponseEntity</code> filtrado pelo novo método <code>findAllByStatus</code>. Foi criado o método <code>findAllByStatus</code> na <code>CourseRepository</code>, na <code>CourseService</code> e na <code>CourseServiceImpl</code>. Essa solução se utiliza da classe <code>StringToEntityStatusEnumConverter</code>, criada no PR #113.

A verificação dessa feature pode ser testada com os seguintes testes em algum software que possa fazer requisições get:
<code>{base_url}/{context}/courses?status=DISABLED</code> deve retornar uma lista de cursos desabilitados.
<code>{base_url}/{context}/courses?status=disabled</code>  deve retornar uma lista de cursos desabilitados.
<code>{base_url}/{context}/courses?courses?status=ENABLED</code>  deve retornar uma lista de cursos habilitados.
<code>{base_url}/{context}/courses?courses?status=enabled</code>  deve retornar uma lista de cursos habilitados.
<code>{base_url}/{context}/courses</code> deve retornar uma lista com todos os cursos
