### PR TITLE
feat: add parameter on index method

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public interface CurriculumRepository extends JpaRepository<Curriculum, UUID> {
     List<Curriculum> findAllByCourseId(UUID courseId);
     Optional<Curriculum> findAllByCourseIdAndId(UUID courseId, UUID curriculumId);
-    List<Curriculum> findByStatus(EntityStatus status);
+    List<Curriculum> findByCourseIdAndStatus(UUID courseId, EntityStatus status);
     @Modifying
     @Query("update Curriculum c set c.status = 'DISABLED' where c.course.id = ?1")
     void disableAllByCourseId(UUID courseId);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public interface CurriculumRepository extends JpaRepository<Curriculum, UUID> {
     List<Curriculum> findAllByCourseId(UUID courseId);
     Optional<Curriculum> findAllByCourseIdAndId(UUID courseId, UUID curriculumId);
-    List<Curriculum> findAllByStatus(EntityStatus status);
+    List<Curriculum> findByStatus(EntityStatus status);
     @Modifying
     @Query("update Curriculum c set c.status = 'DISABLED' where c.course.id = ?1")
     void disableAllByCourseId(UUID courseId);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepository.java
@@ -1,5 +1,6 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
 
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,7 @@ import java.util.UUID;
 public interface CurriculumRepository extends JpaRepository<Curriculum, UUID> {
     List<Curriculum> findAllByCourseId(UUID courseId);
     Optional<Curriculum> findAllByCourseIdAndId(UUID courseId, UUID curriculumId);
+    List<Curriculum> findAllByStatus(EntityStatus status);
     @Modifying
     @Query("update Curriculum c set c.status = 'DISABLED' where c.course.id = ?1")
     void disableAllByCourseId(UUID courseId);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRestController.java
@@ -36,6 +36,15 @@ public class CurriculumRestController {
         @PathVariable UUID courseId,
         @RequestParam(required = false) EntityStatus status
     ) {
+        if (status != null)
+        {
+            return ResponseEntity.ok(curriculumService.findByStatus(courseId, status)
+                    .stream()
+                    .map(curriculumMapper::to)
+                    .collect(Collectors.toList())
+            );
+        }
+
         return ResponseEntity.ok(curriculumService.findAll(courseId)
             .stream()
             .map(curriculumMapper::to)

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRestController.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRestController.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,7 +33,8 @@ public class CurriculumRestController {
 
     @GetMapping
     public ResponseEntity<List<CurriculumDto>> index(
-        @PathVariable UUID courseId
+        @PathVariable UUID courseId,
+        @RequestParam(required = false) EntityStatus status
     ) {
         return ResponseEntity.ok(curriculumService.findAll(courseId)
             .stream()

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumService.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumService.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.dtos.EntityUpdateStatusDto;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import java.util.UUID;
 public interface CurriculumService {
     Curriculum create(UUID courseId, CurriculumCreateDto curriculumCreateDto);
     List<Curriculum> findAll(UUID courseId);
+    List<Curriculum> findByStatus(UUID courseId, EntityStatus status);
     Curriculum findById(UUID courseId, UUID curriculumId);
     Curriculum findByCurriculumId(UUID curriculumId);
     Curriculum update(UUID courseId, UUID curriculumId, CurriculumCreateDto curriculumCreateDto);

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumServiceImpl.java
@@ -54,6 +54,12 @@ public class CurriculumServiceImpl implements CurriculumService {
     }
 
     @Override
+    public List<Curriculum> findByStatus(UUID courseId, EntityStatus status){
+        courseService.findById(courseId);
+        return curriculumRepository.findByStatus(status);
+    }
+
+    @Override
     public Curriculum findByCurriculumId(UUID curriculumId) {
         return curriculumRepository.findById(curriculumId).orElseThrow(
                 () -> new ResourceNotFoundException(ResourceName.CURRICULUM, curriculumId));

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumServiceImpl.java
@@ -56,7 +56,7 @@ public class CurriculumServiceImpl implements CurriculumService {
     @Override
     public List<Curriculum> findByStatus(UUID courseId, EntityStatus status){
         courseService.findById(courseId);
-        return curriculumRepository.findByStatus(status);
+        return curriculumRepository.findByCourseIdAndStatus(courseId, status);
     }
 
     @Override


### PR DESCRIPTION
Resolve a Issue #130 

Conforme requisitado pela Issue #130, foi implementada a filtragem de matrizes de um curso pelo seu campo de status. As modificações necessárias para a resolução da Issue ocorreram todas em componentes do pacote `curriculum` e podem ser comentadas em três partes.

Primeiramente foi declarado na interface `CurriculumRepository` o método `findByCourseIdAndStatus` do tipo `List<Curriculum>` que recebe como parâmetros, como sugerido pelo nome, os atributos `courseId` de uma entidade course e `status` (com tipagem do enum `EntityStatus`) de uma entidade curriculum. A partir disso, então, a interface JpaRepository implementa o método que busca na base de dados matrizes de um curso com o status especificado.

Na interface `CurriculumService` e na classe `CurriculumServiceImpl` foi, respectivamente, declarado e implementado o método `findByStatus` do tipo `List<Curriculum>` que também recebe como parâmetro um `courseId` e um `status`. O método retorna um chamado ao método `findByCourseIdAndStatus` da classe `CurriculumRepository`, mencionada anteriormente. Vale notar, também, que em `CurriculumService` o nome do método foi simplificado para `findByStatus` visto que a maioria dos métodos no serviço usam `courseId` como parâmetro e também não o explicitam na nomeação do método.

Por fim, na classe `CurriculumRestController` foi modificado o método `index`. No seu parâmetro agora é especificado um `EntityStatus status` com a assinatura `@RequestParam(required = false)` para notar que não é um parâmetro obrigatório. Caso no seus parâmetros seja provido um `status` o método `index` retornará uma chamada ao método `findByStatus` do serviço `CurriculumService`, do contrário, retornará uma chamada ao método `findAll` como já previsto na codificação atual do projeto.