### PR TITLE
test: add tests for existsbyabbreviation and findallbystatus methods

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/Application.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/Application.java
@@ -7,14 +7,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 @EnableScheduling
-@Import(RequestExpiresVerification.class)
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceImpl.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceImpl.java
@@ -36,6 +36,11 @@ public class DepartmentServiceImpl implements DepartmentService {
         this.courseService = courseService;
     }
 
+    @Autowired
+    public void setDepartmentRepository(DepartmentRepository departmentRepository) {
+        this.departmentRepository = departmentRepository;
+    }
+
     @Override
     public Department create(UUID campusId, DepartmentCreateDto departmentCreateDto) {
         Campus campus = campusService.findById(campusId);

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusFactoryUtils.java
@@ -1,6 +1,7 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
 
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 
 public class CampusFactoryUtils {
     public static Campus sampleCampus(City city) {
@@ -19,5 +20,44 @@ public class CampusFactoryUtils {
         InternshipSector internshipSector = new InternshipSector(telephone, email, website);
 
         return new Campus(name, abbreviation, initialRegistrationPattern, address, internshipSector);
+    }
+
+    public static Campus sampleCampusEnabled(City city) {
+        String name = "Test Campus";
+        String abbreviation = "TCS";
+        String initialRegistrationPattern = "SP";
+        String postalCode = "123456";
+        String street = "Test Street";
+        String neighborhood = "Test Neighborhood";
+        String number = "123456";
+        String complement = "Test Complement";
+        Address address = new Address(postalCode, street, neighborhood, number, complement, city);
+        String telephone = "1234-5678";
+        String email = "testcampus@email.com";
+        String website = "https://testcampus.com";
+        InternshipSector internshipSector = new InternshipSector(telephone, email, website);
+
+        return new Campus(name, abbreviation, initialRegistrationPattern, address, internshipSector);
+    }
+
+    public static Campus sampleCampusDisabled(City city) {
+        String name = "Test Campus";
+        String abbreviation = "TCS";
+        String initialRegistrationPattern = "SP";
+        String postalCode = "123456";
+        String street = "Test Street";
+        String neighborhood = "Test Neighborhood";
+        String number = "123456";
+        String complement = "Test Complement";
+        Address address = new Address(postalCode, street, neighborhood, number, complement, city);
+        String telephone = "1234-5678";
+        String email = "testcampus@email.com";
+        String website = "https://testcampus.com";
+        InternshipSector internshipSector = new InternshipSector(telephone, email, website);
+
+        Campus campusDisabled =  new Campus(name, abbreviation, initialRegistrationPattern, address, internshipSector);
+        campusDisabled.setStatus(EntityStatus.DISABLED);
+
+        return campusDisabled;
     }
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
@@ -1,50 +1,112 @@
-//package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
-//
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//@DataJpaTest
-//public class CampusRepositoryTest {
-//    @Autowired
-//    private TestEntityManager entityManager;
-//    @Autowired
-//    private CampusRepository campusRepository;
-//
-//    private Campus campus;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
-//        City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
-//        campus = CampusFactoryUtils.sampleCampus(city);
-//    }
-//
-//    @Test
-//    public void saveNewCampus() {
-//        campusRepository.save(campus);
-//        Campus campusFound = entityManager.find(Campus.class, campus.getId());
-//
-//        assertThat(campusFound).isNotNull();
-//        assertThat(campusFound.getId()).isEqualTo(campus.getId());
-//        assertThat(campusFound.getName()).isEqualTo(campus.getName());
-//        assertThat(campusFound.getAbbreviation()).isEqualTo(campus.getAbbreviation());
-//        assertThat(campusFound.getAddress().getPostalCode()).isEqualTo(campus.getAddress().getPostalCode());
-//        assertThat(campusFound.getAddress().getStreet()).isEqualTo(campus.getAddress().getStreet());
-//        assertThat(campusFound.getAddress().getNeighborhood()).isEqualTo(campus.getAddress().getNeighborhood());
-//        assertThat(campusFound.getAddress().getCity()).isEqualTo(campus.getAddress().getCity());
-//        assertThat(campusFound.getAddress().getNumber()).isEqualTo(campus.getAddress().getNumber());
-//        assertThat(campusFound.getAddress().getComplement()).isEqualTo(campus.getAddress().getComplement());
-//        assertThat(campusFound.getInternshipSector().getTelephone()).isEqualTo(campus.getInternshipSector().getTelephone());
-//        assertThat(campusFound.getInternshipSector().getEmail()).isEqualTo(campus.getInternshipSector().getEmail());
-//        assertThat(campusFound.getInternshipSector().getWebsite()).isEqualTo(campus.getInternshipSector().getWebsite());
-//    }
-//}
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class CampusRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private CampusRepository campusRepository;
+
+    private Campus campus;
+    private City city;
+
+    @BeforeEach
+    public void setUp() {
+        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
+        city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
+        campus = CampusFactoryUtils.sampleCampus(city);
+    }
+
+    @Test
+    public void saveNewCampus() {
+        campusRepository.save(campus);
+        Campus campusFound = entityManager.find(Campus.class, campus.getId());
+
+        assertThat(campusFound).isNotNull();
+        assertThat(campusFound.getId()).isEqualTo(campus.getId());
+        assertThat(campusFound.getName()).isEqualTo(campus.getName());
+        assertThat(campusFound.getAbbreviation()).isEqualTo(campus.getAbbreviation());
+        assertThat(campusFound.getAddress().getPostalCode()).isEqualTo(campus.getAddress().getPostalCode());
+        assertThat(campusFound.getAddress().getStreet()).isEqualTo(campus.getAddress().getStreet());
+        assertThat(campusFound.getAddress().getNeighborhood()).isEqualTo(campus.getAddress().getNeighborhood());
+        assertThat(campusFound.getAddress().getCity()).isEqualTo(campus.getAddress().getCity());
+        assertThat(campusFound.getAddress().getNumber()).isEqualTo(campus.getAddress().getNumber());
+        assertThat(campusFound.getAddress().getComplement()).isEqualTo(campus.getAddress().getComplement());
+        assertThat(campusFound.getInternshipSector().getTelephone()).isEqualTo(campus.getInternshipSector().getTelephone());
+        assertThat(campusFound.getInternshipSector().getEmail()).isEqualTo(campus.getInternshipSector().getEmail());
+        assertThat(campusFound.getInternshipSector().getWebsite()).isEqualTo(campus.getInternshipSector().getWebsite());
+    }
+
+    @Test
+    public void findAllByStatusShouldReturnOnlyEnabledCampusesWhenSpecifiedStatusIsEnabled() {
+        Campus campusEnabled = campus;
+        Campus campusEnabled2 = CampusFactoryUtils.sampleCampus(city);
+        Campus campusDisabled = CampusFactoryUtils.sampleCampus(city);
+        campusDisabled.setStatus(EntityStatus.DISABLED);
+        entityManager.persistAndFlush(campusEnabled);
+        entityManager.persistAndFlush(campusEnabled2);
+        entityManager.persistAndFlush(campusDisabled);
+
+        List<Campus> campuses = campusRepository.findAllByStatus(EntityStatus.ENABLED);
+
+        assertThat(campuses).hasSize(2);
+        assertThat(campuses.get(0).getId()).isEqualTo(campusEnabled.getId());
+        assertThat(campuses.get(1).getId()).isEqualTo(campusEnabled2.getId());
+    }
+
+    @Test
+    public void findAllByStatusShouldReturnEmptyListWhenThereIsNotCampusWithEnabledStatus() {
+        campus.setStatus(EntityStatus.DISABLED);
+        Campus campusDisabled = campus;
+        entityManager.persistAndFlush(campusDisabled);
+
+        List<Campus> campuses = campusRepository.findAllByStatus(EntityStatus.ENABLED);
+
+        assertThat(campuses).isEmpty();
+    }
+
+    @Test
+    public void findAllByStatusShouldReturnOnlyDisabledCampusesWhenSpecifiedStatusIsDisabled() {
+        Campus campusDisabled = CampusFactoryUtils.sampleCampus(city);
+        campusDisabled.setStatus(EntityStatus.DISABLED);
+        Campus campusDisabled2 = CampusFactoryUtils.sampleCampus(city);
+        campusDisabled2.setStatus(EntityStatus.DISABLED);
+        Campus campusEnabled = campus;
+        entityManager.persistAndFlush(campusDisabled);
+        entityManager.persistAndFlush(campusDisabled2);
+        entityManager.persistAndFlush(campusEnabled);
+
+        List<Campus> campuses = campusRepository.findAllByStatus(EntityStatus.DISABLED);
+
+        assertThat(campuses).hasSize(2);
+        assertThat(campuses.get(0).getId()).isEqualTo(campusDisabled.getId());
+        assertThat(campuses.get(1).getId()).isEqualTo(campusDisabled2.getId());
+    }
+
+    @Test
+    public void findAllByStatusShouldReturnEmptyListWhenThereIsNotCampusWithDisabledStatus() {
+        Campus campusEnabled = campus;
+        entityManager.persistAndFlush(campusEnabled);
+
+        List<Campus> campuses = campusRepository.findAllByStatus(EntityStatus.DISABLED);
+
+        assertThat(campuses).isEmpty();
+    }
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
@@ -7,8 +7,6 @@ import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -108,5 +106,23 @@ public class CampusRepositoryTest {
         List<Campus> campuses = campusRepository.findAllByStatus(EntityStatus.DISABLED);
 
         assertThat(campuses).isEmpty();
+    }
+
+    @Test
+    public void existsByAbbreviationShouldReturnTrueWhenThereIsCampusWithSpecifiedAbbreviation() {
+        entityManager.persistAndFlush(campus);
+
+        boolean result = campusRepository.existsByAbbreviation("TCS");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void existsByAbbreviationShouldReturnFalseWhenThereIsNotCampusWithSpecifiedAbbreviation() {
+        entityManager.persistAndFlush(campus);
+
+        boolean result = campusRepository.existsByAbbreviation("SPO");
+
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -97,8 +97,6 @@ public class DepartmentServiceTest {
     public void findAll() {
         Campus campus1 = campus;
         Department department = new Department("Departamento A","DPA", campus1);
-        DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento A", "DPA");
-
         when(departmentRepository.findAllByCampusId(any(UUID.class)))
                 .thenReturn(List.of(department));
 

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,15 +68,14 @@ public class DepartmentServiceTest {
         State state = StateFactoryUtils.sampleState();
         City city = CityFactoryUtils.sampleCity(state);
         Campus campus = CampusFactoryUtils.sampleCampus(city);
+        Department department = new Department("Departamento A","DPA", campus);
         DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento A", "DPA");
-        when(departmentRepository.existsByAbbreviationAndCampusId(
-                departmentCreateDto.getAbbreviation(),
-                campus.getId())
-        ).thenReturn(true);
+        when(departmentRepository.existsByAbbreviationAndCampusId(anyString(), any(UUID.class)))
+                .thenReturn(true);
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(campus);
 
-        assertThatThrownBy(() -> departmentService.create(campus.getId(), departmentCreateDto))
+        assertThatThrownBy(() -> departmentService.create(department.getCampus().getId(), departmentCreateDto))
                 .isInstanceOf(DepartmentAlreadyExistsByAbbreviationAndCampusIdException.class);
     }
 
@@ -82,35 +84,41 @@ public class DepartmentServiceTest {
         State state = StateFactoryUtils.sampleState();
         City city = CityFactoryUtils.sampleCity(state);
         Campus campus = CampusFactoryUtils.sampleCampus(city);
-        campus.setStatus(EntityStatus.DISABLED);
         Department department = new Department("Departamento A","DPA", campus);
+        campus.setStatus(EntityStatus.DISABLED);
         DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento A", "DPA");
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(campus);
 
-        assertThatThrownBy(() -> departmentService.create(campus.getId(), departmentCreateDto))
+        assertThatThrownBy(() -> departmentService.create(department.getCampus().getId(), departmentCreateDto))
                 .isInstanceOf(ResourceReferentialIntegrityException.class);
     }
-//
-//    @Test
-//    public void findAll() {
-//        getCampus();
-//        when(departmentRepository.findAllByCampusId(department.getCampus().getId())).thenReturn(List.of(department));
-//
-//        List<Department> departments = departmentService.findAll(department.getCampus().getId());
-//
-//        assertThat(departments).hasSize(1);
-//    }
-//
-//    @Test
-//    public void findAllEmpty() {
-//        getCampus();
-//        when(departmentRepository.findAllByCampusId(department.getCampus().getId())).thenReturn(Collections.emptyList());
-//
-//        List<Department> departments = departmentService.findAll(department.getCampus().getId());
-//
-//        assertThat(departments).isEmpty();
-//    }
+
+    @Test
+    public void findAll() {
+        State state = StateFactoryUtils.sampleState();
+        City city = CityFactoryUtils.sampleCity(state);
+        Campus campus = CampusFactoryUtils.sampleCampus(city);
+        Department department = new Department("Departamento A","DPA", campus);
+        when(departmentRepository.findAllByCampusId(any(UUID.class))).thenReturn(List.of(department));
+
+        List<Department> departments = departmentService.findAll(department.getCampus().getId());
+
+        assertThat(departments).hasSize(1);
+    }
+
+    @Test
+    public void findAllEmpty() {
+        State state = StateFactoryUtils.sampleState();
+        City city = CityFactoryUtils.sampleCity(state);
+        Campus campus = CampusFactoryUtils.sampleCampus(city);
+        Department department = new Department("Departamento A","DPA", campus);
+        when(departmentRepository.findAllByCampusId(any(UUID.class))).thenReturn(Collections.emptyList());
+
+        List<Department> departments = departmentService.findAll(department.getCampus().getId());
+
+        assertThat(departments).isEmpty();
+    }
 //
 //    @Test
 //    public void findById() {

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -6,6 +6,7 @@ import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.CampusService;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.exceptions.ResourceNotFoundException;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.exceptions.ResourceReferentialIntegrityException;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course.CourseService;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
@@ -18,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -119,26 +121,32 @@ public class DepartmentServiceTest {
 
         assertThat(departments).isEmpty();
     }
-//
-//    @Test
-//    public void findById() {
-//        getCampus();
-//        getDepartment();
-//
-//        Department departmentFound = departmentService.findById(department.getCampus().getId(), department.getId());
-//
-//        assertThat(departmentFound).isNotNull();
-//        assertThat(departmentFound.getId()).isEqualTo(department.getId());
-//    }
-//
-//    @Test
-//    public void findByIdNotFound() {
-//        getCampus();
-//        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class))).thenReturn(Optional.empty());
-//
-//        assertThatThrownBy(() -> departmentService.findById(department.getCampus().getId(), department.getId()))
-//            .isInstanceOf(ResourceNotFoundException.class);
-//    }
+
+    @Test
+    public void findById() {
+        State state = StateFactoryUtils.sampleState();
+        City city = CityFactoryUtils.sampleCity(state);
+        Campus campus = CampusFactoryUtils.sampleCampus(city);
+        Department department = new Department("Departamento A","DPA", campus);
+        when(departmentRepository.findById(any(UUID.class))).thenReturn(Optional.of(department));
+
+        Department departmentFound = departmentService.findById(department.getId());
+
+        assertThat(departmentFound).isNotNull();
+        assertThat(departmentFound.getId()).isEqualTo(department.getId());
+    }
+
+    @Test
+    public void findByIdNotFound() {
+        State state = StateFactoryUtils.sampleState();
+        City city = CityFactoryUtils.sampleCity(state);
+        Campus campus = CampusFactoryUtils.sampleCampus(city);
+        Department department = new Department("Departamento A","DPA", campus);
+        when(departmentRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> departmentService.findById(department.getId()))
+            .isInstanceOf(ResourceNotFoundException.class);
+    }
 //
 //    @Test
 //    public void updateDepartment() {

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -189,32 +189,30 @@ public class DepartmentServiceTest {
                 departmentCreateDto
         )).isInstanceOf(DepartmentAlreadyExistsByAbbreviationAndCampusIdException.class);
     }
-//
-//    @Test
-//    public void deleteCampus() {
-//        getCampus();
-//        getDepartment();
-//
-//        departmentService.delete(department.getCampus().getId(), department.getId());
-//
-//        verify(departmentRepository, times(1)).deleteById(department.getId());
-//    }
-//
-//    @Test
-//    public void deleteCampusNotFound() {
-//        when(campusRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
-//        assertThatThrownBy(() -> departmentService.delete(department.getCampus().getId(), department.getId()))
-//            .isInstanceOf(ResourceNotFoundException.class);
-//    }
-//
-//    @Test
-//    public void deleteDepartmentNotFound() {
-//        getCampus();
-//        when(departmentRepository.findByCampusIdAndId(department.getCampus().getId(), department.getId()))
-//            .thenReturn(Optional.empty());
-//        assertThatThrownBy(() -> departmentService.delete(department.getCampus().getId(), department.getId()))
-//            .isInstanceOf(ResourceNotFoundException.class);
-//    }
-//
-//
+
+    @Test
+    public void deleteCampus() {
+        when(campusService.findById(any(UUID.class)))
+                .thenReturn(department.getCampus());
+        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Optional.of(department));
+        when(courseService.existsByDepartmentId(any(UUID.class)))
+                .thenReturn(false);
+
+        departmentService.delete(department.getCampus().getId(), department.getId());
+
+        verify(departmentRepository, times(1)).deleteById(department.getId());
+    }
+
+    @Test
+    public void deleteDepartmentNotFound() {
+        when(campusService.findById(any(UUID.class)))
+                .thenReturn(department.getCampus());
+        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> departmentService.delete(department.getCampus().getId(), department.getId()))
+            .isInstanceOf(ResourceNotFoundException.class);
+    }
+
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -35,7 +35,6 @@ public class DepartmentServiceTest {
     private CourseService courseService;
     private DepartmentServiceImpl departmentService;
     private Department department;
-    private Campus campus;
 
     @BeforeEach
     public void setUp() {
@@ -44,7 +43,7 @@ public class DepartmentServiceTest {
        departmentService.setCourseService(courseService);
        State state = StateFactoryUtils.sampleState();
        City city = CityFactoryUtils.sampleCity(state);
-       campus = CampusFactoryUtils.sampleCampus(city);
+       Campus campus = CampusFactoryUtils.sampleCampus(city);
        department = new Department("Departamento A","DPA", campus);
     }
 
@@ -130,7 +129,7 @@ public class DepartmentServiceTest {
 
     @Test
     public void updateDepartment() {
-        Department departmentReturnedByRepository = new Department("Departamento B","DPB", campus);
+        Department departmentReturnedByRepository = new Department("Departamento B","DPB", department.getCampus());
         DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento B", "DPB");
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(department.getCampus());
@@ -157,7 +156,7 @@ public class DepartmentServiceTest {
 
     @Test
     public void updateDepartmentNotFound() {
-        DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento A", "DPA");
+        DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento B", "DPB");
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(department.getCampus());
         when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
@@ -172,7 +171,7 @@ public class DepartmentServiceTest {
 
     @Test
     public void updateDepartmentAlreadyExistsByAbbreviationAndCampusIdExcludedId() {
-        DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento A", "DPA");
+        DepartmentCreateDto departmentCreateDto = new DepartmentCreateDto("Departamento B", "DPB");
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(department.getCampus());
         when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
@@ -191,7 +190,7 @@ public class DepartmentServiceTest {
     }
 
     @Test
-    public void deleteCampus() {
+    public void deleteDepartment() {
         when(campusService.findById(any(UUID.class)))
                 .thenReturn(department.getCampus());
         when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
@@ -213,6 +212,26 @@ public class DepartmentServiceTest {
 
         assertThatThrownBy(() -> departmentService.delete(department.getCampus().getId(), department.getId()))
             .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    public void existsByCampusId() {
+       when(departmentRepository.existsByCampusId(any(UUID.class)))
+               .thenReturn(true);
+
+       boolean result = departmentService.existsByCampusId(department.getCampus().getId());
+
+       assertThat(result).isTrue();
+    }
+
+    @Test
+    public void departmentNotExistsByCampusId() {
+        when(departmentRepository.existsByCampusId(any(UUID.class)))
+                .thenReturn(false);
+
+        boolean result = departmentService.existsByCampusId(department.getCampus().getId());
+
+        assertThat(result).isFalse();
     }
 
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -232,6 +231,28 @@ public class DepartmentServiceTest {
         boolean result = departmentService.existsByCampusId(department.getCampus().getId());
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    public void disableAllByCampusId() {
+        when(departmentRepository.findAllByCampusId(any(UUID.class)))
+                .thenReturn(List.of(department));
+
+        departmentService.disableAllByCampusId(department.getCampus().getId());
+
+        verify(courseService, times(1)).disableAllByDepartmentId(department.getId());
+        verify(departmentRepository, times(1)).disableAllByCampusId(department.getCampus().getId());
+    }
+
+    @Test
+    public void notDisableAllByCampusIdNotExists() {
+        when(departmentRepository.findAllByCampusId(any(UUID.class)))
+                .thenReturn(Collections.emptyList());
+
+        departmentService.disableAllByCampusId(department.getCampus().getId());
+        verify(departmentRepository, times(1)).findAllByCampusId(department.getCampus().getId());
+        verify(courseService, times(0)).disableAllByDepartmentId(department.getId());
+        verify(courseService, times(0)).disableAllByDepartmentId(department.getId());
     }
 
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentServiceTest.java
@@ -255,4 +255,42 @@ public class DepartmentServiceTest {
         verify(courseService, times(0)).disableAllByDepartmentId(department.getId());
     }
 
+    @Test
+    public void enable() {
+        department.setStatus(EntityStatus.DISABLED);
+        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Optional.of(department));
+        when(departmentRepository.save(any(Department.class)))
+                .thenReturn(department);
+
+        Department departmentEnabled = departmentService.enable(department.getCampus().getId(), department.getId());
+
+        assertThat(departmentEnabled.getStatus()).isEqualTo(EntityStatus.ENABLED);
+    }
+
+    @Test
+    public void enableWhenCampusIsDisabled() {
+        department.setStatus(EntityStatus.DISABLED);
+        department.getCampus().setStatus(EntityStatus.DISABLED);
+        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Optional.of(department));
+        when(campusService.enable(any(UUID.class)))
+                .thenReturn(department.getCampus());
+        when(departmentRepository.save(any(Department.class)))
+                .thenReturn(department);
+
+        Department departmentEnabled = departmentService.enable(department.getCampus().getId(), department.getId());
+
+        assertThat(departmentEnabled.getStatus()).isEqualTo(EntityStatus.ENABLED);
+    }
+
+    @Test
+    public void notEnableWhenDepartmentIsNotFound() {
+        department.setStatus(EntityStatus.DISABLED);
+        when(departmentRepository.findByCampusIdAndId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> departmentService.enable(department.getCampus().getId(), department.getId()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
 }


### PR DESCRIPTION
Relacionado a issue #120

Este pull request adiciona testes aos métodos `existsByAbbreviation` e `findAllByStatus` da classe `CampusRepository` e aos métodos `create`, `findAll`, `findById`, `findByCampusIdAndId`, `update`, `setStatus`, `delete`, `existsByCampusId`, `disableAllByCampusId` e `enable` da classe `DepartmentServiceImpl`. 

Para verificar se essas modificações funcionam, basta rodar os testes criados no IDE.