### PR TITLE
test: add test to curriculumrepositorytest findbycourseidandstatus

### DIFF
--- a/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/Application.java
+++ b/src/main/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/Application.java
@@ -14,7 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 @EnableScheduling
-@Import(RequestExpiresVerification.class)
+//@Import(RequestExpiresVerification.class)
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/campus/CampusRepositoryTest.java
@@ -1,50 +1,50 @@
-//package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
-//
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//@DataJpaTest
-//public class CampusRepositoryTest {
-//    @Autowired
-//    private TestEntityManager entityManager;
-//    @Autowired
-//    private CampusRepository campusRepository;
-//
-//    private Campus campus;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
-//        City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
-//        campus = CampusFactoryUtils.sampleCampus(city);
-//    }
-//
-//    @Test
-//    public void saveNewCampus() {
-//        campusRepository.save(campus);
-//        Campus campusFound = entityManager.find(Campus.class, campus.getId());
-//
-//        assertThat(campusFound).isNotNull();
-//        assertThat(campusFound.getId()).isEqualTo(campus.getId());
-//        assertThat(campusFound.getName()).isEqualTo(campus.getName());
-//        assertThat(campusFound.getAbbreviation()).isEqualTo(campus.getAbbreviation());
-//        assertThat(campusFound.getAddress().getPostalCode()).isEqualTo(campus.getAddress().getPostalCode());
-//        assertThat(campusFound.getAddress().getStreet()).isEqualTo(campus.getAddress().getStreet());
-//        assertThat(campusFound.getAddress().getNeighborhood()).isEqualTo(campus.getAddress().getNeighborhood());
-//        assertThat(campusFound.getAddress().getCity()).isEqualTo(campus.getAddress().getCity());
-//        assertThat(campusFound.getAddress().getNumber()).isEqualTo(campus.getAddress().getNumber());
-//        assertThat(campusFound.getAddress().getComplement()).isEqualTo(campus.getAddress().getComplement());
-//        assertThat(campusFound.getInternshipSector().getTelephone()).isEqualTo(campus.getInternshipSector().getTelephone());
-//        assertThat(campusFound.getInternshipSector().getEmail()).isEqualTo(campus.getInternshipSector().getEmail());
-//        assertThat(campusFound.getInternshipSector().getWebsite()).isEqualTo(campus.getInternshipSector().getWebsite());
-//    }
-//}
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class CampusRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private CampusRepository campusRepository;
+
+    private Campus campus;
+
+    @BeforeEach
+    public void setUp() {
+        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
+        City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
+        campus = CampusFactoryUtils.sampleCampus(city);
+    }
+
+    @Test
+    public void saveNewCampus() {
+        campusRepository.save(campus);
+        Campus campusFound = entityManager.find(Campus.class, campus.getId());
+
+        assertThat(campusFound).isNotNull();
+        assertThat(campusFound.getId()).isEqualTo(campus.getId());
+        assertThat(campusFound.getName()).isEqualTo(campus.getName());
+        assertThat(campusFound.getAbbreviation()).isEqualTo(campus.getAbbreviation());
+        assertThat(campusFound.getAddress().getPostalCode()).isEqualTo(campus.getAddress().getPostalCode());
+        assertThat(campusFound.getAddress().getStreet()).isEqualTo(campus.getAddress().getStreet());
+        assertThat(campusFound.getAddress().getNeighborhood()).isEqualTo(campus.getAddress().getNeighborhood());
+        assertThat(campusFound.getAddress().getCity()).isEqualTo(campus.getAddress().getCity());
+        assertThat(campusFound.getAddress().getNumber()).isEqualTo(campus.getAddress().getNumber());
+        assertThat(campusFound.getAddress().getComplement()).isEqualTo(campus.getAddress().getComplement());
+        assertThat(campusFound.getInternshipSector().getTelephone()).isEqualTo(campus.getInternshipSector().getTelephone());
+        assertThat(campusFound.getInternshipSector().getEmail()).isEqualTo(campus.getInternshipSector().getEmail());
+        assertThat(campusFound.getInternshipSector().getWebsite()).isEqualTo(campus.getInternshipSector().getWebsite());
+    }
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseFactoryUtils.java
@@ -1,16 +1,14 @@
-//package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
-//
-//
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.Department;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.DepartmentFactoryUtils;
-//
-//public class CourseFactoryUtils {
-//    public static Course sampleCourse() {
-//        String name = "Test Course";
-//        String abbreviation = "TC";
-//        Integer numberOfPeriods = 6;
-//        Department department = DepartmentFactoryUtils.sampleDepartment();
-//
-//        return new Course(name, abbreviation, numberOfPeriods, department);
-//    }
-//}
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
+
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.Department;
+
+public class CourseFactoryUtils {
+    public static Course sampleCourse(Department department) {
+        String name = "Test Course";
+        String abbreviation = "TC";
+        Integer numberOfPeriods = 6;
+
+        return new Course(name, abbreviation, numberOfPeriods, department);
+    }
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
@@ -1,0 +1,35 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.Campus;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.CampusFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.Department;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.DepartmentFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+public class CourseRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private CourseRepository courseRepository;
+
+    private Course course;
+
+    @BeforeEach
+    public void setUp() {
+        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
+        City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
+        Campus campus = entityManager.persistAndFlush(CampusFactoryUtils.sampleCampus(city));
+        Department department = entityManager.persistAndFlush(DepartmentFactoryUtils.sampleDepartment(campus));
+        course = CourseFactoryUtils.sampleCourse(department);
+    }
+
+    //boolean existsByAbbreviationAndDepartmentIdExcludedId(String abbreviation, UUID departmentId, UUID courseId);
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
@@ -22,31 +22,37 @@ public class CourseRepositoryTest {
     private TestEntityManager entityManager;
     @Autowired
     private CourseRepository courseRepository;
-
-    private Department department;
-    private Course course;
+    private Campus campus;
 
     @BeforeEach
     public void setUp() {
         State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
         City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
-        Campus campus = entityManager.persistAndFlush(CampusFactoryUtils.sampleCampus(city));
-        department = entityManager.persistAndFlush(DepartmentFactoryUtils.sampleDepartment(campus));
-        course = CourseFactoryUtils.sampleCourse(department);
+        campus = entityManager.persistAndFlush(CampusFactoryUtils.sampleCampus(city));
     }
 
     @Test
     public void existsByAbbreviationAndDepartmentIdExcludedId()
     {
-        Course course0 = course;
-        Course course1 = CourseFactoryUtils.sampleCourse(department);
+        Department department0 = DepartmentFactoryUtils.sampleDepartment(campus);
+        Department department1 = DepartmentFactoryUtils.sampleDepartment(campus);
+        entityManager.persistAndFlush(department0);
+        entityManager.persistAndFlush(department1);
+        Course course0 = CourseFactoryUtils.sampleCourse(department0);
+        Course course1 = CourseFactoryUtils.sampleCourse(department0);
+        Course course2 = CourseFactoryUtils.sampleCourse(department1);
+        course0.setAbbreviation("TADS");
+        course1.setAbbreviation("INF");
+        course2.setAbbreviation("TADS");
         entityManager.persistAndFlush(course0);
         entityManager.persistAndFlush(course1);
+        entityManager.persistAndFlush(course2);
 
+        course1.setAbbreviation("TADS");
         boolean exists = courseRepository.existsByAbbreviationAndDepartmentIdExcludedId(
-                course0.getAbbreviation(),
-                course0.getDepartment().getId(),
-                course0.getId());
+                course1.getAbbreviation(),
+                course1.getDepartment().getId(),
+                course1.getId());
 
         assertThat(exists).isTrue();
     }
@@ -54,16 +60,25 @@ public class CourseRepositoryTest {
     @Test
     public void existsByAbbreviationAndDepartmentIdExcludedIdReturnsFalseWhenAbbreviationDiffers()
     {
-        Course course0 = course;
-        Course course1 = CourseFactoryUtils.sampleCourse(department);
-        course1.setAbbreviation("TCP");
+        Department department0 = DepartmentFactoryUtils.sampleDepartment(campus);
+        Department department1 = DepartmentFactoryUtils.sampleDepartment(campus);
+        entityManager.persistAndFlush(department0);
+        entityManager.persistAndFlush(department1);
+        Course course0 = CourseFactoryUtils.sampleCourse(department0);
+        Course course1 = CourseFactoryUtils.sampleCourse(department0);
+        Course course2 = CourseFactoryUtils.sampleCourse(department1);
+        course0.setAbbreviation("TADS");
+        course1.setAbbreviation("INF");
+        course2.setAbbreviation("TADS");
         entityManager.persistAndFlush(course0);
         entityManager.persistAndFlush(course1);
+        entityManager.persistAndFlush(course2);
 
+        course1.setAbbreviation("INF2");
         boolean exists = courseRepository.existsByAbbreviationAndDepartmentIdExcludedId(
-                course0.getAbbreviation(),
-                course0.getDepartment().getId(),
-                course0.getId());
+                course1.getAbbreviation(),
+                course1.getDepartment().getId(),
+                course1.getId());
 
         assertThat(exists).isFalse();
     }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
@@ -9,9 +9,12 @@ import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.DepartmentFactor
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 public class CourseRepositoryTest {
@@ -20,6 +23,7 @@ public class CourseRepositoryTest {
     @Autowired
     private CourseRepository courseRepository;
 
+    private Department department;
     private Course course;
 
     @BeforeEach
@@ -27,9 +31,40 @@ public class CourseRepositoryTest {
         State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
         City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
         Campus campus = entityManager.persistAndFlush(CampusFactoryUtils.sampleCampus(city));
-        Department department = entityManager.persistAndFlush(DepartmentFactoryUtils.sampleDepartment(campus));
+        department = entityManager.persistAndFlush(DepartmentFactoryUtils.sampleDepartment(campus));
         course = CourseFactoryUtils.sampleCourse(department);
     }
 
-    //boolean existsByAbbreviationAndDepartmentIdExcludedId(String abbreviation, UUID departmentId, UUID courseId);
+    @Test
+    public void existsByAbbreviationAndDepartmentIdExcludedId()
+    {
+        Course course0 = CourseFactoryUtils.sampleCourse(department);
+        Course course1 = CourseFactoryUtils.sampleCourse(department);
+        entityManager.persistAndFlush(course0);
+        entityManager.persistAndFlush(course1);
+
+        boolean exists = courseRepository.existsByAbbreviationAndDepartmentIdExcludedId(
+                course0.getAbbreviation(),
+                course0.getDepartment().getId(),
+                course0.getId());
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    public void existsByAbbreviationAndDepartmentIdExcludedId_ReturnsFalse_WhenAbbreviationDiffers()
+    {
+        Course course0 = CourseFactoryUtils.sampleCourse(department);
+        Course course1 = CourseFactoryUtils.sampleCourse(department);
+        course1.setAbbreviation("TCP");
+        entityManager.persistAndFlush(course0);
+        entityManager.persistAndFlush(course1);
+
+        boolean exists = courseRepository.existsByAbbreviationAndDepartmentIdExcludedId(
+                course0.getAbbreviation(),
+                course0.getDepartment().getId(),
+                course0.getId());
+
+        assertThat(exists).isFalse();
+    }
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/course/CourseRepositoryTest.java
@@ -38,7 +38,7 @@ public class CourseRepositoryTest {
     @Test
     public void existsByAbbreviationAndDepartmentIdExcludedId()
     {
-        Course course0 = CourseFactoryUtils.sampleCourse(department);
+        Course course0 = course;
         Course course1 = CourseFactoryUtils.sampleCourse(department);
         entityManager.persistAndFlush(course0);
         entityManager.persistAndFlush(course1);
@@ -52,9 +52,9 @@ public class CourseRepositoryTest {
     }
 
     @Test
-    public void existsByAbbreviationAndDepartmentIdExcludedId_ReturnsFalse_WhenAbbreviationDiffers()
+    public void existsByAbbreviationAndDepartmentIdExcludedIdReturnsFalseWhenAbbreviationDiffers()
     {
-        Course course0 = CourseFactoryUtils.sampleCourse(department);
+        Course course0 = course;
         Course course1 = CourseFactoryUtils.sampleCourse(department);
         course1.setAbbreviation("TCP");
         entityManager.persistAndFlush(course0);

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
@@ -1,0 +1,15 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course.Course;
+
+public class CurriculumFactoryUtils {
+    public static Curriculum sampleCurriculum(Course course){
+        String code = "1001";
+        Integer courseLoad = 1001;
+        Integer internshipCourseLoad = 360;
+        String internshipStartCriteria = "Test internship start criteria";
+        String internshipAllowedActivities = "Test internship allowed activities";
+
+        return new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
+    }
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
@@ -1,5 +1,6 @@
 package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
 
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
 import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course.Course;
 
 public class CurriculumFactoryUtils {
@@ -11,5 +12,29 @@ public class CurriculumFactoryUtils {
         String internshipAllowedActivities = "Test internship allowed activities";
 
         return new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
+    }
+
+    public static Curriculum sampleCurriculumEnabled(Course course){
+        String code = "1001";
+        Integer courseLoad = 1001;
+        Integer internshipCourseLoad = 360;
+        String internshipStartCriteria = "Test internship start criteria";
+        String internshipAllowedActivities = "Test internship allowed activities";
+
+        var curriculum = new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
+        curriculum.setStatus(EntityStatus.ENABLED);
+        return curriculum;
+    }
+
+    public static Curriculum sampleCurriculumDisabled(Course course){
+        String code = "1001";
+        Integer courseLoad = 1001;
+        Integer internshipCourseLoad = 360;
+        String internshipStartCriteria = "Test internship start criteria";
+        String internshipAllowedActivities = "Test internship allowed activities";
+
+        var curriculum = new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
+        curriculum.setStatus(EntityStatus.DISABLED);
+        return curriculum;
     }
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumFactoryUtils.java
@@ -15,25 +15,11 @@ public class CurriculumFactoryUtils {
     }
 
     public static Curriculum sampleCurriculumEnabled(Course course){
-        String code = "1001";
-        Integer courseLoad = 1001;
-        Integer internshipCourseLoad = 360;
-        String internshipStartCriteria = "Test internship start criteria";
-        String internshipAllowedActivities = "Test internship allowed activities";
-
-        var curriculum = new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
-        curriculum.setStatus(EntityStatus.ENABLED);
-        return curriculum;
+        return sampleCurriculum(course);
     }
 
     public static Curriculum sampleCurriculumDisabled(Course course){
-        String code = "1001";
-        Integer courseLoad = 1001;
-        Integer internshipCourseLoad = 360;
-        String internshipStartCriteria = "Test internship start criteria";
-        String internshipAllowedActivities = "Test internship allowed activities";
-
-        var curriculum = new Curriculum(code, courseLoad, internshipCourseLoad, internshipStartCriteria, internshipAllowedActivities, course);
+        var curriculum = sampleCurriculum(course);
         curriculum.setStatus(EntityStatus.DISABLED);
         return curriculum;
     }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -45,10 +45,9 @@ public class CurriculumRepositoryTest {
 
     @Test
     public void findByCourseIdAndStatusReturnsOnlyEnabledCourses() {
-        Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
-        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
-        Curriculum curriculumDisabled = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumDisabled.setStatus(EntityStatus.DISABLED);
+        Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculumEnabled(course);
+        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculumEnabled(course);
+        Curriculum curriculumDisabled = CurriculumFactoryUtils.sampleCurriculumDisabled(course);
         entityManager.persistAndFlush(curriculumEnabled0);
         entityManager.persistAndFlush(curriculumEnabled1);
         entityManager.persistAndFlush(curriculumDisabled);
@@ -57,18 +56,15 @@ public class CurriculumRepositoryTest {
 
         assertThat(curriculumList)
                 .hasSize(2)
-                .doesNotContain(curriculumDisabled);
-        assertThat(curriculumList.get(0)).isEqualTo(curriculumEnabled0);
-        assertThat(curriculumList.get(1)).isEqualTo(curriculumEnabled1);
+                .extracting(Curriculum::getStatus)
+                .containsExactlyInAnyOrder(EntityStatus.ENABLED, EntityStatus.ENABLED);
     }
 
     @Test
     public void findByCourseIdAndStatusReturnsOnlyDisabledCourses() {
-        Curriculum curriculumEnabled = CurriculumFactoryUtils.sampleCurriculum(course);
-        Curriculum curriculumDisabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
-        Curriculum curriculumDisabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumDisabled0.setStatus(EntityStatus.DISABLED);
-        curriculumDisabled1.setStatus(EntityStatus.DISABLED);
+        Curriculum curriculumEnabled = CurriculumFactoryUtils.sampleCurriculumEnabled(course);
+        Curriculum curriculumDisabled0 = CurriculumFactoryUtils.sampleCurriculumDisabled(course);
+        Curriculum curriculumDisabled1 = CurriculumFactoryUtils.sampleCurriculumDisabled(course);
         entityManager.persistAndFlush(curriculumEnabled);
         entityManager.persistAndFlush(curriculumDisabled0);
         entityManager.persistAndFlush(curriculumDisabled1);
@@ -77,9 +73,8 @@ public class CurriculumRepositoryTest {
 
         assertThat(curriculumList)
                 .hasSize(2)
-                .doesNotContain(curriculumEnabled);
-        assertThat(curriculumList.get(0)).isEqualTo(curriculumDisabled0);
-        assertThat(curriculumList.get(1)).isEqualTo(curriculumDisabled1);
+                .extracting(Curriculum::getStatus)
+                .containsExactlyInAnyOrder(EntityStatus.DISABLED, EntityStatus.DISABLED);
     }
 
     @Test

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -44,7 +44,7 @@ public class CurriculumRepositoryTest {
     }
 
     @Test
-    public void findByCourseIdAndStatus_ReturnsOnlyEnabledCourses() {
+    public void findByCourseIdAndStatusReturnsOnlyEnabledCourses() {
         Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumDisabled = CurriculumFactoryUtils.sampleCurriculum(course);
@@ -63,7 +63,7 @@ public class CurriculumRepositoryTest {
     }
 
     @Test
-    public void findByCourseIdAndStatus_ReturnsOnlyDisabledCourses() {
+    public void findByCourseIdAndStatusReturnsOnlyDisabledCourses() {
         Curriculum curriculumEnabled = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumDisabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumDisabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
@@ -117,7 +117,7 @@ public class CurriculumRepositoryTest {
     }
 
     @Test
-    public void disableAllByCourseId_DoesNotDisableCurriculumsFromOtherCourses()
+    public void disableAllByCourseIdDoesNotDisableCurriculumsFromOtherCourses()
     {
         Curriculum curriculum0 = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculum1 = CurriculumFactoryUtils.sampleCurriculum(course);

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -44,47 +44,40 @@ public class CurriculumRepositoryTest {
     }
 
     @Test
-    public void findByCourseIdAndStatus() {
+    public void findByCourseIdAndStatus_ReturnsOnlyEnabledCourses() {
         Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumEnabled0.setStatus(EntityStatus.ENABLED);
+        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumDisabled = CurriculumFactoryUtils.sampleCurriculum(course);
         curriculumDisabled.setStatus(EntityStatus.DISABLED);
-        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumEnabled1.setStatus(EntityStatus.ENABLED);
-
         entityManager.persistAndFlush(curriculumEnabled0);
-        entityManager.persistAndFlush(curriculumDisabled);
         entityManager.persistAndFlush(curriculumEnabled1);
+        entityManager.persistAndFlush(curriculumDisabled);
 
         List<Curriculum> curriculumList = curriculumRepository.findByCourseIdAndStatus(curriculum.getCourse().getId(), EntityStatus.ENABLED);
 
-        assertThat(curriculumList).hasSize(2);
-        assertThat(curriculumList).doesNotContain(curriculumDisabled);
+        assertThat(curriculumList)
+                .hasSize(2)
+                .doesNotContain(curriculumDisabled);
         assertThat(curriculumList.get(0)).isEqualTo(curriculumEnabled0);
         assertThat(curriculumList.get(1)).isEqualTo(curriculumEnabled1);
     }
 
     @Test
     public void findByCourseIdAndStatus_ReturnsOnlyDisabledCourses() {
+        Curriculum curriculumEnabled = CurriculumFactoryUtils.sampleCurriculum(course);
         Curriculum curriculumDisabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumDisabled0.setStatus(EntityStatus.DISABLED);
         Curriculum curriculumDisabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumDisabled0.setStatus(EntityStatus.DISABLED);
         curriculumDisabled1.setStatus(EntityStatus.DISABLED);
-        Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumEnabled0.setStatus(EntityStatus.ENABLED);
-        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
-        curriculumEnabled1.setStatus(EntityStatus.ENABLED);
-
+        entityManager.persistAndFlush(curriculumEnabled);
         entityManager.persistAndFlush(curriculumDisabled0);
         entityManager.persistAndFlush(curriculumDisabled1);
-        entityManager.persistAndFlush(curriculumEnabled0);
-        entityManager.persistAndFlush(curriculumEnabled1);
 
         List<Curriculum> curriculumList = curriculumRepository.findByCourseIdAndStatus(curriculum.getCourse().getId(), EntityStatus.DISABLED);
 
-        assertThat(curriculumList).hasSize(2);
-        assertThat(curriculumList).doesNotContain(curriculumEnabled0);
-        assertThat(curriculumList).doesNotContain(curriculumEnabled1);
+        assertThat(curriculumList)
+                .hasSize(2)
+                .doesNotContain(curriculumEnabled);
         assertThat(curriculumList.get(0)).isEqualTo(curriculumDisabled0);
         assertThat(curriculumList.get(1)).isEqualTo(curriculumDisabled1);
     }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +89,25 @@ public class CurriculumRepositoryTest {
         assertThat(curriculumList.get(1)).isEqualTo(curriculumDisabled1);
     }
 
-    //TODO existsByCourseId(UUID courseId);
+    @Test
+    public void existsByCourseId()
+    {
+        entityManager.persistAndFlush(curriculum);
+
+        boolean exists = curriculumRepository.existsByCourseId(curriculum.getCourse().getId());
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    public void notExistsByCourseId()
+    {
+        entityManager.persistAndFlush(curriculum);
+
+        boolean exists = curriculumRepository.existsByCourseId(UUID.randomUUID());
+
+        assertThat(exists).isFalse();
+    }
 
     //TODO disableAllByCourseId(UUID courseId);
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -109,5 +109,31 @@ public class CurriculumRepositoryTest {
         assertThat(exists).isFalse();
     }
 
-    //TODO disableAllByCourseId(UUID courseId);
+    @Test
+    public void disableAllByCourseId()
+    {
+        Curriculum curriculum0 = CurriculumFactoryUtils.sampleCurriculum(course);
+        Curriculum curriculum1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        entityManager.persistAndFlush(curriculum0);
+        entityManager.persistAndFlush(curriculum1);
+
+        curriculumRepository.disableAllByCourseId(curriculum.getCourse().getId());
+
+        assertThat(curriculum0.getStatus().equals(EntityStatus.DISABLED));
+        assertThat(curriculum1.getStatus().equals(EntityStatus.DISABLED));
+    }
+
+    @Test
+    public void disableAllByCourseId_DoesNotDisableCurriculumsFromOtherCourses()
+    {
+        Curriculum curriculum0 = CurriculumFactoryUtils.sampleCurriculum(course);
+        Curriculum curriculum1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        entityManager.persistAndFlush(curriculum0);
+        entityManager.persistAndFlush(curriculum1);
+
+        curriculumRepository.disableAllByCourseId(UUID.randomUUID());
+
+        assertThat(curriculum0.getStatus().equals(EntityStatus.ENABLED));
+        assertThat(curriculum1.getStatus().equals(EntityStatus.ENABLED));
+    }
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -1,0 +1,65 @@
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.curriculum;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.Campus;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.CampusFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.City;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.city.CityFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.common.enums.EntityStatus;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course.Course;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.course.CourseFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.Department;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department.DepartmentFactoryUtils;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.State;
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.state.StateFactoryUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class CurriculumRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CurriculumRepository curriculumRepository;
+
+    private Curriculum curriculum;
+    private Course course;
+
+    @BeforeEach
+    public void setUp() {
+        State state = entityManager.persistAndFlush(StateFactoryUtils.sampleState());
+        City city = entityManager.persistAndFlush(CityFactoryUtils.sampleCity(state));
+        Campus campus = entityManager.persistAndFlush(CampusFactoryUtils.sampleCampus(city));
+        Department department = entityManager.persistAndFlush(DepartmentFactoryUtils.sampleDepartment(campus));
+        course = entityManager.persistAndFlush(CourseFactoryUtils.sampleCourse(department));
+        curriculum = CurriculumFactoryUtils.sampleCurriculum(course);
+    }
+
+    @Test
+    public void findByCourseIdAndStatus() {
+        Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumEnabled0.setStatus(EntityStatus.ENABLED);
+        Curriculum curriculumDisabled = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumDisabled.setStatus(EntityStatus.DISABLED);
+        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumEnabled1.setStatus(EntityStatus.ENABLED);
+
+        entityManager.persistAndFlush(curriculumEnabled0);
+        entityManager.persistAndFlush(curriculumDisabled);
+        entityManager.persistAndFlush(curriculumEnabled1);
+
+        List<Curriculum> curriculumList = curriculumRepository.findByCourseIdAndStatus(curriculum.getCourse().getId(), EntityStatus.ENABLED);
+
+        assertThat(curriculumList).hasSize(2);
+        assertThat(curriculumList).doesNotContain(curriculumDisabled);
+        assertThat(curriculumList.get(0)).isEqualTo(curriculumEnabled0);
+        assertThat(curriculumList.get(1)).isEqualTo(curriculumEnabled1);
+    }
+}

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/curriculum/CurriculumRepositoryTest.java
@@ -62,4 +62,33 @@ public class CurriculumRepositoryTest {
         assertThat(curriculumList.get(0)).isEqualTo(curriculumEnabled0);
         assertThat(curriculumList.get(1)).isEqualTo(curriculumEnabled1);
     }
+
+    @Test
+    public void findByCourseIdAndStatus_ReturnsOnlyDisabledCourses() {
+        Curriculum curriculumDisabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumDisabled0.setStatus(EntityStatus.DISABLED);
+        Curriculum curriculumDisabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumDisabled1.setStatus(EntityStatus.DISABLED);
+        Curriculum curriculumEnabled0 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumEnabled0.setStatus(EntityStatus.ENABLED);
+        Curriculum curriculumEnabled1 = CurriculumFactoryUtils.sampleCurriculum(course);
+        curriculumEnabled1.setStatus(EntityStatus.ENABLED);
+
+        entityManager.persistAndFlush(curriculumDisabled0);
+        entityManager.persistAndFlush(curriculumDisabled1);
+        entityManager.persistAndFlush(curriculumEnabled0);
+        entityManager.persistAndFlush(curriculumEnabled1);
+
+        List<Curriculum> curriculumList = curriculumRepository.findByCourseIdAndStatus(curriculum.getCourse().getId(), EntityStatus.DISABLED);
+
+        assertThat(curriculumList).hasSize(2);
+        assertThat(curriculumList).doesNotContain(curriculumEnabled0);
+        assertThat(curriculumList).doesNotContain(curriculumEnabled1);
+        assertThat(curriculumList.get(0)).isEqualTo(curriculumDisabled0);
+        assertThat(curriculumList.get(1)).isEqualTo(curriculumDisabled1);
+    }
+
+    //TODO existsByCourseId(UUID courseId);
+
+    //TODO disableAllByCourseId(UUID courseId);
 }

--- a/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentFactoryUtils.java
+++ b/src/test/java/br/edu/ifsp/ifspcodelab/gestaoestagiosbackend/department/DepartmentFactoryUtils.java
@@ -1,16 +1,13 @@
-//package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department;
-//
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.Campus;
-//import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.CampusFactoryUtils;
-//
-//public class DepartmentFactoryUtils {
-//    public static Department sampleDepartment() {
-//        Campus campus = CampusFactoryUtils.sampleCampus();
-//        return new Department("Test Department", "TDP", campus);
-//    }
-//
-//    public static Department sampleDepartment(String name, String abbreviation, Campus campus) {
-//        return new Department(name, abbreviation, campus);
-//    }
-//
-//}
+package br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.department;
+
+import br.edu.ifsp.ifspcodelab.gestaoestagiosbackend.campus.Campus;
+
+public class DepartmentFactoryUtils {
+    public static Department sampleDepartment(Campus campus)
+    {
+        String name = "Test Department";
+        String abbreviation = "TDP";
+        return new Department(name, abbreviation, campus);
+    }
+
+}


### PR DESCRIPTION
Resolves #140, resolves #141

Neste Pull Request, para solucionar as Issues #140 e #141, foram criadadas três classes e modificadas quatro. A primeira modificação na classe `Application` foi necessária para executar os testes codificados, visto que a linha 17 `@Import(RequestExpiresVerification.class)` causa um erro que impossibilita essas execuções. A modificação na classe `CampusRepositoryTest`, embora alheia aos conteúdos das Issues, ocorreu para testar inicialmente o ambiente de testes dado o erro mencionado anteriormente.

Para resolver o item "Implementar o teste do método `existsByAbbreviationAndDepartmentIdExcludedId`" (#141) foi necessária a criação da classe `CourseRepositoryTest` e nela implementar três métodos, sendo dois deles o teste em si. O primeiro método `public void setUp()`, com assinatura `@BeforeEach`, contém a criação de objetos *sample* que são usados durante as execuções dos testes. O método `existsByAbbreviationAndDepartmentIdExcludedId()` testa o método considerando um retorno boolean true, enquanto o método ` existsByAbbreviationAndDepartmentIdExcludedIdReturnsFalseWhenAbbreviationDiffers()` testa o retorno false. Ambos os métodos foram assinados com `@Test`.

Na resolução dos itens da Issue #140 foram criadas as classes `CurriculumFactoryUtils` e `CurriculumRepositoryTest`. Na primeira classe há um construtor `sampleCurriculum` que retorna um objeto sample de tipo `Curriculum` a ser utilizado nos testes efetuados em `CurriculumRepositoryTest`, que além de também contar com um método `public void setUp()` contém os testes `findByCourseIdAndStatusReturnsOnlyEnabledCourses()`, `existsByCourseId()` e `disableAllByCourseId()`. Todos os testes foram assinados com `@Test` e são métodos `public`.

Referências:
Este Pull Request — e também a resolução integral das Issues #140 e #141 — relaciona-se com os seguintes PRs:
- GH-143
- GH-144